### PR TITLE
Improve per-env configuration

### DIFF
--- a/lib/phoenix/sync/electric.ex
+++ b/lib/phoenix/sync/electric.ex
@@ -305,18 +305,6 @@ defmodule Phoenix.Sync.Electric do
   end
 
   defp embedded_children(env, mode, opts) do
-    electric_children(env, mode, opts)
-  end
-
-  # don't start embedded electric in :test env because electric
-  # creates replication slots and doesn't play well with
-  # async tests
-  # defp electric_children(:test, :embedded, _opts) do
-  #   Logger.info("Not starting embedded electric in test mode")
-  #   {:ok, []}
-  # end
-
-  defp electric_children(env, mode, opts) do
     case validate_database_config(env, mode, opts) do
       {:start, db_config_fun, message} ->
         start_embedded(env, mode, db_config_fun, message)
@@ -405,19 +393,6 @@ defmodule Phoenix.Sync.Electric do
     # if we want to use emphemeral dir for dev storage then we have to persist
     # the storage_dir into the application config.
     opts
-    # |> Keyword.put_new(
-    #   :storage_dir,
-    #   Path.join(System.tmp_dir!(), "electric/shape-data#{System.monotonic_time()}")
-    # )
-    # |> Keyword.put_new(
-    #   :storage,
-    #   {Electric.ShapeCache.InMemoryStorage,
-    #    table_base_name: :"electric-storage#{opts[:stack_id]}", stack_id: opts[:stack_id]}
-    # )
-    # |> Keyword.put_new(
-    #   :persistent_kv,
-    #   {Electric.PersistentKV.Memory, :new!, []}
-    # )
     |> Keyword.put_new(:send_cache_headers?, false)
   end
 

--- a/lib/phoenix/sync/electric.ex
+++ b/lib/phoenix/sync/electric.ex
@@ -282,15 +282,10 @@ defmodule Phoenix.Sync.Electric do
 
   if @electric_available? do
     defp plug_opts(env, :embedded, electric_opts) do
-      if electric_available?() do
-        env
-        |> core_configuration(electric_opts)
-        |> Electric.Application.api_plug_opts()
-        |> Keyword.fetch!(:api)
-      else
-        raise RuntimeError,
-          message: "Configured for embedded mode but `:electric` dependency not installed"
-      end
+      env
+      |> core_configuration(electric_opts)
+      |> Electric.Application.api_plug_opts()
+      |> Keyword.fetch!(:api)
     end
   else
     defp plug_opts(_env, :embedded, _electric_opts) do

--- a/lib/phoenix/sync/plug.ex
+++ b/lib/phoenix/sync/plug.ex
@@ -395,7 +395,7 @@ defmodule Phoenix.Sync.Plug do
       end
 
   """
-  @spec send_configuration(Plug.Conn.t(), Phoenix.Sync.shape_definition(), Client.t()) ::
+  @spec send_configuration(Plug.Conn.t(), Phoenix.Sync.shape_definition(), Electric.Client.t()) ::
           Plug.Conn.t()
   def send_configuration(conn, shape_or_queryable, client \\ Phoenix.Sync.client!()) do
     shape = normalise_shape(shape_or_queryable)

--- a/test/phoenix/sync/application_test.exs
+++ b/test/phoenix/sync/application_test.exs
@@ -86,15 +86,11 @@ defmodule Phoenix.Sync.ApplicationTest do
 
       validate_repo_connection_opts!(opts)
 
-      # assert %{
-      #          storage: {Electric.ShapeCache.FileStorage, [storage_dir: "/tmp/" <> storage_dir]},
-      #          persistent_kv: %Electric.PersistentKV.Filesystem{
-      #            root: "/tmp/" <> storage_dir
-      #          }
-      #        } = Map.new(opts)
       assert %{
-               storage: {Electric.ShapeCache.InMemoryStorage, _},
-               persistent_kv: %Electric.PersistentKV.Memory{}
+               storage: {Electric.ShapeCache.FileStorage, [storage_dir: "/tmp/" <> storage_dir]},
+               persistent_kv: %Electric.PersistentKV.Filesystem{
+                 root: "/tmp/" <> storage_dir
+               }
              } = Map.new(opts)
     end
 
@@ -158,14 +154,9 @@ defmodule Phoenix.Sync.ApplicationTest do
       validate_repo_connection_opts!(opts)
 
       assert %{
-               storage: {Electric.ShapeCache.InMemoryStorage, _},
-               persistent_kv: %Electric.PersistentKV.Memory{}
+               storage: {Electric.ShapeCache.FileStorage, [storage_dir: "/something"]},
+               persistent_kv: %Electric.PersistentKV.Filesystem{root: "/something"}
              } = Map.new(opts)
-
-      # assert %{
-      #          storage: {Electric.ShapeCache.FileStorage, [storage_dir: "/something"]},
-      #          persistent_kv: %Electric.PersistentKV.Filesystem{root: "/something"}
-      #        } = Map.new(opts)
     end
 
     test "embedded mode test env" do
@@ -263,13 +254,9 @@ defmodule Phoenix.Sync.ApplicationTest do
 
       api = App.plug_opts(config)
 
-      # assert %Electric.Shapes.Api{
-      #          storage: {Electric.ShapeCache.FileStorage, %{base_path: "/something" <> _}},
-      #          persistent_kv: %Electric.PersistentKV.Filesystem{root: "/something"}
-      #        } = api
       assert %Electric.Shapes.Api{
-               storage: {Electric.ShapeCache.InMemoryStorage, _},
-               persistent_kv: %Electric.PersistentKV.Memory{}
+               storage: {Electric.ShapeCache.FileStorage, %{base_path: "/something" <> _}},
+               persistent_kv: %Electric.PersistentKV.Filesystem{root: "/something"}
              } = api
     end
 


### PR DESCRIPTION
Use temporary slots and per-run slot names in test. Also fix compilation warnings when electric not installed.

Fixes #3