### PR TITLE
Specify an exact electric version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,9 @@ defmodule Phoenix.Sync.MixProject do
       {:plug, "~> 1.0"},
       {:jason, "~> 1.0"},
       {:ecto_sql, "~> 3.10", optional: true},
-      {:electric, ">= 1.0.0-beta.20", optional: true},
+      # require an exact version because electric moves very quickly atm
+      # and a more generous specification would inevitably break.
+      {:electric, "== 1.0.0-beta.20", optional: true},
       {:electric_client, ">= 0.3.0-beta.4"}
     ] ++ deps_for_env(Mix.env())
   end


### PR DESCRIPTION
Current electric main breaks configuration. If we specify a >= version then the next publish of electric will break this package.