### PR TITLE
Warn if no `env` set in config

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,6 @@
 import Config
 
-config :logger, level: :critical
+config :logger, level: :warning
 
 config :phoenix_sync, mode: :disabled
 


### PR DESCRIPTION
We can't infer the env of the parent app, so without this explict config value electric will always launch in prod mode with persistent shapes.

Addresses #56 which is caused by shapes being persisted between server restarts