### PR TITLE
Add support for changeset shapes

### DIFF
--- a/lib/phoenix/sync.ex
+++ b/lib/phoenix/sync.ex
@@ -183,7 +183,7 @@ defmodule Phoenix.Sync do
   end
 
   @doc """
-  Interrupts all long-polling requests maching the give shape definition.
+  Interrupts all long-polling requests matching the given shape definition.
 
   The broader the shape definition, the more requests will be interrupted.
 

--- a/lib/phoenix/sync/application.ex
+++ b/lib/phoenix/sync/application.ex
@@ -9,6 +9,8 @@ defmodule Phoenix.Sync.Application do
 
   @impl true
   def start(_type, _args) do
+    base_children = [Phoenix.Sync.ShapeRequestRegistry]
+
     children =
       case children() do
         {:ok, children} ->
@@ -19,7 +21,10 @@ defmodule Phoenix.Sync.Application do
           []
       end
 
-    Supervisor.start_link(children, strategy: :one_for_one, name: Phoenix.Sync.Supervisor)
+    Supervisor.start_link(base_children ++ children,
+      strategy: :one_for_one,
+      name: Phoenix.Sync.Supervisor
+    )
   end
 
   @doc false

--- a/lib/phoenix/sync/client.ex
+++ b/lib/phoenix/sync/client.ex
@@ -124,26 +124,16 @@ defmodule Phoenix.Sync.Client do
   end
 
   @doc false
-  def stream(shape, stream_opts, sync_opts) do
-    client = new!(sync_opts)
-    {shape, shape_stream_opts} = resolve_shape(shape)
-    Electric.Client.stream(client, shape, Keyword.merge(shape_stream_opts, stream_opts))
+  # used for testing. `config` replace the application configuration
+  def stream(shape, stream_opts, config) do
+    client = new!(config)
+    {shape, stream_opts} = resolve_shape(shape, stream_opts)
+    Electric.Client.stream(client, shape, stream_opts)
   end
 
-  defp resolve_shape(table) when is_binary(table) do
-    {table, []}
-  end
-
-  defp resolve_shape(definition) when is_list(definition) do
-    shape = PredefinedShape.new!(definition)
-    PredefinedShape.to_stream_params(shape)
-  end
-
-  defp resolve_shape(schema) when is_atom(schema) do
-    {schema, []}
-  end
-
-  defp resolve_shape(%Ecto.Query{} = query) do
-    {query, []}
+  defp resolve_shape(shape, stream_opts) do
+    shape
+    |> PredefinedShape.new!(stream_opts)
+    |> Phoenix.Sync.PredefinedShape.to_stream_params()
   end
 end

--- a/lib/phoenix/sync/controller.ex
+++ b/lib/phoenix/sync/controller.ex
@@ -43,35 +43,34 @@ defmodule Phoenix.Sync.Controller do
 
   ## Shape definitions
 
-  Shape definitions can be any of the following:
+  See `Phoenix.Sync.shape!/2` for examples of shape definitions
 
-  - An `Ecto.Schema` module:
+  ## Interruptible requests
 
-        sync_render(conn, MyPlugApp.Todos.Todo)
+  There may be circumstances where shape definitions are dynamic based on, say,
+  a database query. In this case you should wrap your shape definitions in a
+  function and use `sync_render/3` so that changes to clients' shapes can be.
+  immediately picked up by the clients.
 
-  - An `Ecto` query:
-
-        sync_render(conn, params, from(t in Todos.Todo, where: t.owner_id == ^user_id))
-
-  - A `changeset/1` function which defines the table and columns:
-
-        sync_render(conn, params, &Todos.Todo.changeset/1)
-
-  - A `changeset/1` function plus a where clause:
-
-        sync_render(conn, params, &Todos.Todo.changeset/1, where: "completed = false")
-
-    or a parameterized where clause:
-
-        sync_render(conn, params, &Todos.Todo.changeset/1, where: "completed = $1", params: [false])
-
-  - A keyword list defining the shape parameters:
-
-        sync_render(conn, params, table: "todos", namespace: "my_app", where: "completed = $1", params: [false])
+  For more information see `Phoenix.Sync.Controller.sync_render/3` and
+  `Phoenix.Sync.interrupt/2`.
   """
 
+  alias Phoenix.Sync.Adapter
   alias Phoenix.Sync.Plug.CORS
   alias Phoenix.Sync.PredefinedShape
+  alias Phoenix.Sync.ShapeRequestRegistry
+
+  require Logger
+
+  @type shape_option() :: PredefinedShape.option()
+  @type shape_options() :: [shape_option()]
+
+  if Code.ensure_loaded?(Ecto) do
+    @type shape() :: shape_options() | Electric.Client.ecto_shape()
+  else
+    @type shape() :: shape_options()
+  end
 
   defmacro __using__(opts \\ []) do
     # validate that we're being used in the context of a Plug.Router impl
@@ -84,56 +83,235 @@ defmodule Phoenix.Sync.Controller do
                           Phoenix.Sync.Controller
                         )
 
-      def sync_render(conn, shape) do
-        case get_in(conn.assigns, [@plug_assign_opts, :phoenix_sync]) do
-          %_{} = api ->
-            conn =
-              conn
-              |> Plug.Conn.fetch_query_params()
-              |> Plug.Conn.put_private(:phoenix_sync_api, api)
-
-            Phoenix.Sync.Controller.sync_render(conn, conn.params, shape)
-
-          nil ->
-            raise RuntimeError,
-              message:
-                "Please configure your Router opts with [phoenix_sync: Phoenix.Sync.plug_opts()]"
-        end
+      def sync_render(conn, shape_fun) when is_function(shape_fun, 0) do
+        conn
+        |> Phoenix.Sync.Controller.configure_plug_conn!(@plug_assign_opts)
+        |> Phoenix.Sync.Controller.sync_render(conn.params, shape_fun)
       end
+
+      def sync_render(conn, shape, shape_opts \\ []) do
+        conn
+        |> Phoenix.Sync.Controller.configure_plug_conn!(@plug_assign_opts)
+        |> Phoenix.Sync.Controller.sync_render(conn.params, shape, shape_opts)
+      end
+    end
+  end
+
+  @doc false
+  def configure_plug_conn!(conn, assign_opts) do
+    case get_in(conn.assigns, [assign_opts, :phoenix_sync]) do
+      %_{} = api ->
+        conn
+        |> Plug.Conn.fetch_query_params()
+        |> Plug.Conn.put_private(:phoenix_sync_api, api)
+
+      nil ->
+        raise RuntimeError,
+          message:
+            "Please configure your Router opts with [phoenix_sync: Phoenix.Sync.plug_opts()]"
+    end
+  end
+
+  @doc """
+  Return the sync events for the given shape with an interruptible response.
+
+  By passing the shape definition as a function you enable interruptible
+  requests. This is useful when the shape definition is dynamic and may change.
+
+  By interrupting the long running requests to the sync API, changes to the
+  client's shape can be picked up immediately without waiting for the long-poll
+  timeout to expire.
+
+  For instance, when creating a task manager apps your clients will have a list
+  of tasks and each task will have a set of steps.
+
+  So the controller code the `steps` sync endpoint might look like this:
+
+      def steps(conn, %{"user_id" => user_id} = params) do
+        task_ids =
+          from(t in Tasks.Task, where: t.user_id == ^user_id, select: t.id)
+          |> Repo.all()
+
+        steps_query =
+          Enum.reduce(
+            task_ids,
+            from(s in Tasks.Step),
+            fn query, task_id -> or_where(query, [s], s.task_id == ^task_id) end
+          )
+
+        sync_render(conn, params, steps_query)
+      end
+
+  This works but when the user adds a new task, existing requests from clients
+  won't pick up new tasks until active long-poll requests complete, which means
+  that new tasks may not appear in the page until up to 20 seconds later.
+
+  To handle this situation you can make your `sync_render/3` call interruptible
+  like so:
+
+      def steps(conn, %{"user_id" => user_id} = params) do
+        sync_render(conn, params, fn ->
+          task_ids =
+            from(t in Tasks.Task, where: t.user_id == ^user_id, select: t.id)
+            |> Repo.all()
+
+          Enum.reduce(
+            task_ids,
+            from(s in Tasks.Step),
+            fn query, task_id -> or_where(query, [s], s.task_id == ^task_id) end
+          )
+        end)
+      end
+
+  And add an interrupt call in your tasks controller to trigger the interrupt:
+
+      def create(conn, %{"user_id" => user_id, "task" => task_params}) do
+        # create the task as before...
+
+        # interrupt all active steps shapes
+        Phoenix.Sync.interrupt(Tasks.Step)
+
+        # return the response...
+      end
+
+  Now active long-poll requests to the `steps` table will be interrupted and
+  re-tried and clients will receive the updated shape data including the new
+  task immediately.
+
+  If you want to use keyword-based shapes instead of Ecto queries or add
+  options to Ecto shapes, you can use `Phoenix.Sync.shape!/2` in the shape
+  definition function:
+
+      sync_render(conn, params, fn ->
+        Phoenix.Sync.shape!(query, replica: :full)
+      end)
+
+  """
+  @spec sync_render(
+          Plug.Conn.t(),
+          Plug.Conn.params(),
+          (-> PredefinedShape.t() | PredefinedShape.shape())
+        ) :: Plug.Conn.t()
+  def sync_render(conn, params, shape_fun) when is_function(shape_fun, 0) do
+    api = configured_api!(conn)
+
+    if interruptible_call?(params) do
+      conn
+      |> CORS.call()
+      |> interruptible_call(api, params, shape_fun)
+    else
+      predefined_shape = call_shape_fun(shape_fun)
+      sync_render_call(conn, api, params, predefined_shape)
     end
   end
 
   @doc """
   Return the sync events for the given shape as a `Plug.Conn` response.
   """
-  @spec sync_render(
-          Plug.Conn.t(),
-          Plug.Conn.params(),
-          PredefinedShape.shape(),
-          PredefinedShape.options()
-        ) :: Plug.Conn.t()
+  @spec sync_render(Plug.Conn.t(), Plug.Conn.params(), shape(), shape_options()) :: Plug.Conn.t()
   def sync_render(conn, params, shape, shape_opts \\ [])
 
-  def sync_render(%{private: %{phoenix_endpoint: endpoint}} = conn, params, shape, shape_opts) do
-    api =
-      endpoint.config(:phoenix_sync) ||
-        raise RuntimeError,
-          message:
-            "Please configure your Endpoint with [phoenix_sync: Phoenix.Sync.plug_opts()] in your `c:Application.start/2`"
+  def sync_render(conn, params, shape, shape_opts) do
+    api = configured_api!(conn)
+    predefined_shape = PredefinedShape.new!(shape, shape_opts)
+    sync_render_call(conn, api, params, predefined_shape)
+  end
 
-    sync_render_api(conn, api, params, shape, shape_opts)
+  # The Phoenix.Controller version
+  defp configured_api!(%{private: %{phoenix_endpoint: endpoint}} = _conn) do
+    endpoint.config(:phoenix_sync) ||
+      raise RuntimeError,
+        message:
+          "Please configure your Endpoint with [phoenix_sync: Phoenix.Sync.plug_opts()] in your `c:Application.start/2`"
   end
 
   # the Plug.{Router, Builder} version
-  def sync_render(%{private: %{phoenix_sync_api: api}} = conn, params, shape, shape_opts) do
-    sync_render_api(conn, api, params, shape, shape_opts)
+  defp configured_api!(%{private: %{phoenix_sync_api: api}} = _conn) do
+    api
   end
 
-  defp sync_render_api(conn, api, params, shape, shape_opts) do
-    predefined_shape = PredefinedShape.new!(shape, shape_opts)
-
+  defp sync_render_call(conn, api, params, predefined_shape) do
     {:ok, shape_api} = Phoenix.Sync.Adapter.PlugApi.predefined_shape(api, predefined_shape)
 
     Phoenix.Sync.Adapter.PlugApi.call(shape_api, CORS.call(conn), params)
+  end
+
+  defp interruptible_call(conn, api, params, shape_fun) do
+    predefined_shape = call_shape_fun(shape_fun)
+
+    {:ok, shape_api} = Adapter.PlugApi.predefined_shape(api, predefined_shape)
+
+    {:ok, key} = ShapeRequestRegistry.register_shape(predefined_shape)
+
+    try do
+      parent = self()
+      start_time = now()
+
+      {:ok, pid} =
+        Task.start_link(fn ->
+          send(parent, {:response, self(), Adapter.PlugApi.call(shape_api, conn, params)})
+        end)
+
+      ref = Process.monitor(pid)
+
+      receive do
+        {:interrupt_shape, ^key, :server_interrupt} ->
+          Process.demonitor(ref, [:flush])
+          Process.unlink(pid)
+          Process.exit(pid, :kill)
+          # immediately retry the same request -- if the shape_fun returns a
+          # different shape the client will receive a must-refetch response but
+          # if the shape is the same then the request will continue with no
+          # interruption.
+          #
+          # if possible adjust the long poll timeout to account for the time
+          # already spent before the interrupt.
+
+          api = reduce_long_poll_timeout(api, start_time)
+
+          interruptible_call(conn, api, params, shape_fun)
+
+        {:response, ^pid, conn} ->
+          Process.demonitor(ref, [:flush])
+
+          conn
+
+        {:DOWN, ^ref, :process, _pid, reason} ->
+          Plug.Conn.send_resp(conn, 500, inspect(reason))
+      end
+    after
+      ShapeRequestRegistry.unregister_shape(key)
+    end
+  end
+
+  defp interruptible_call?(params) do
+    params["live"] == "true"
+  end
+
+  defp now, do: System.monotonic_time(:millisecond)
+
+  # only calls to the embedded api can have their timeout's adjusted
+  defp reduce_long_poll_timeout(%{long_poll_timeout: long_poll_timeout} = api, start_time) do
+    timeout = long_poll_timeout - (now() - start_time)
+
+    Logger.debug(fn ->
+      ["Restarting interrupted request with timeout: ", to_string(timeout), "ms"]
+    end)
+
+    %{api | long_poll_timeout: timeout}
+  end
+
+  defp reduce_long_poll_timeout(api_impl, _start_time) do
+    api_impl
+  end
+
+  defp call_shape_fun(shape_fun) when is_function(shape_fun, 0) do
+    case shape_fun.() do
+      %PredefinedShape{} = predefined_shape ->
+        predefined_shape
+
+      shape_defn ->
+        PredefinedShape.new!(shape_defn)
+    end
   end
 end

--- a/lib/phoenix/sync/electric/client_adapter.ex
+++ b/lib/phoenix/sync/electric/client_adapter.ex
@@ -18,6 +18,9 @@ defmodule Phoenix.Sync.Electric.ClientAdapter do
        }}
     end
 
+    # this is the server-defined shape route, so we want to only pass on the
+    # per-request/stream position params leaving the shape-definition params
+    # from the configured client.
     def call(%{shape_definition: %PredefinedShape{}} = sync_client, conn, params) do
       request =
         Client.request(
@@ -32,6 +35,7 @@ defmodule Phoenix.Sync.Electric.ClientAdapter do
       fetch_upstream(sync_client, conn, request)
     end
 
+    # this version is the pure client-defined shape version
     def call(sync_client, %{method: method} = conn, params) do
       request =
         Client.request(
@@ -48,9 +52,9 @@ defmodule Phoenix.Sync.Electric.ClientAdapter do
 
     defp fetch_upstream(sync_client, conn, request) do
       response =
-        case Electric.Client.Fetch.request(sync_client.client, request) do
-          {:error, response} -> response
-          response -> response
+        case Client.Fetch.request(sync_client.client, request) do
+          %Client.Fetch.Response{} = response -> response
+          {:error, %Client.Fetch.Response{} = response} -> response
         end
 
       conn

--- a/lib/phoenix/sync/predefined_shape.ex
+++ b/lib/phoenix/sync/predefined_shape.ex
@@ -1,6 +1,4 @@
 defmodule Phoenix.Sync.PredefinedShape do
-  @moduledoc false
-
   # A self-contained way to hold shape definition information, alongside stream
   # configuration, compatible with both the embedded and HTTP API versions.
   # Defers to the client code to validate shape options, so we can keep up with
@@ -42,7 +40,8 @@ defmodule Phoenix.Sync.PredefinedShape do
   ]
 
   @type t :: %__MODULE__{}
-  @type options() :: [unquote(NimbleOptions.option_typespec(@public_schema))]
+  @type option() :: unquote(NimbleOptions.option_typespec(@public_schema))
+  @type options() :: [option()]
 
   if Code.ensure_loaded?(Ecto) do
     @type shape() :: options() | Electric.Client.ecto_shape()
@@ -50,8 +49,13 @@ defmodule Phoenix.Sync.PredefinedShape do
     @type shape() :: options()
   end
 
-  def schema, do: @public_schema
+  @doc false
+  def shape_schema, do: @shape_schema
 
+  @doc false
+  def schema, do: @keyword_shape_schema
+
+  @doc false
   @spec new!(shape(), options()) :: t()
   def new!(opts, config \\ [])
 
@@ -122,12 +126,14 @@ defmodule Phoenix.Sync.PredefinedShape do
     Electric.Client.merge_params(client, to_client_params(predefined_shape))
   end
 
+  @doc false
   def to_client_params(%__MODULE__{} = predefined_shape) do
     predefined_shape
     |> to_shape_definition()
     |> ShapeDefinition.params()
   end
 
+  @doc false
   def to_api_params(%__MODULE__{} = predefined_shape) do
     predefined_shape
     |> to_shape_definition()
@@ -135,6 +141,14 @@ defmodule Phoenix.Sync.PredefinedShape do
     |> Keyword.merge(predefined_shape.api_config)
   end
 
+  @doc false
+  def to_shape_params(%__MODULE__{} = predefined_shape) do
+    predefined_shape
+    |> to_shape_definition()
+    |> ShapeDefinition.params(format: :keyword)
+  end
+
+  @doc false
   def to_stream_params(%__MODULE__{} = predefined_shape) do
     {to_shape_definition(predefined_shape), predefined_shape.stream_config}
   end

--- a/lib/phoenix/sync/predefined_shape.ex
+++ b/lib/phoenix/sync/predefined_shape.ex
@@ -160,6 +160,12 @@ defmodule Phoenix.Sync.PredefinedShape do
   # we resolve the query at runtime to avoid compile-time dependencies in
   # router modules
   defp to_shape_definition(%__MODULE__{query: queryable, shape_config: shape_config}) do
-    Electric.Client.EctoAdapter.shape!(queryable, shape_config)
+    try do
+      Electric.Client.EctoAdapter.shape!(queryable, shape_config)
+    rescue
+      e in Protocol.UndefinedError ->
+        raise ArgumentError,
+          message: "Invalid query `#{inspect(queryable)}`: #{e.description}"
+    end
   end
 end

--- a/lib/phoenix/sync/predefined_shape.ex
+++ b/lib/phoenix/sync/predefined_shape.ex
@@ -3,169 +3,149 @@ defmodule Phoenix.Sync.PredefinedShape do
 
   # A self-contained way to hold shape definition information, alongside stream
   # configuration, compatible with both the embedded and HTTP API versions.
+  # Defers to the client code to validate shape options, so we can keep up with
+  # changes to the api without duplicating changes here
 
   alias Electric.Client.ShapeDefinition
 
-  @keys [
-    :relation,
-    :where,
-    :columns,
-    :replica,
-    :storage
+  shape_schema_gen = fn required? ->
+    Keyword.take(
+      [table: [type: :string, required: required?]] ++ ShapeDefinition.schema_definition(),
+      ShapeDefinition.public_keys()
+    )
+  end
+
+  @shape_definition_schema shape_schema_gen.(false)
+  @keyword_shape_schema shape_schema_gen.(true)
+
+  @api_schema_opts [
+    storage: [type: {:or, [:map, nil]}]
   ]
 
-  @schema NimbleOptions.new!(
-            table: [type: :string],
-            query: [type: {:or, [:atom, {:struct, Ecto.Query}]}, doc: false],
-            namespace: [type: :string, default: "public"],
-            where: [type: :string],
-            columns: [type: {:list, :string}],
-            replica: [type: {:in, [:default, :full]}],
-            storage: [type: {:or, [:map, nil]}]
-          )
+  @shape_schema NimbleOptions.new!(@shape_definition_schema)
+  @api_schema NimbleOptions.new!(@api_schema_opts)
+  @stream_schema Electric.Client.Stream.options_schema()
+  @public_schema NimbleOptions.new!(@shape_definition_schema ++ @api_schema_opts)
 
-  defstruct [:query | @keys]
+  @api_schema_keys Keyword.keys(@api_schema_opts)
+  @stream_schema_keys Keyword.keys(@stream_schema.schema)
+  @shape_definition_keys ShapeDefinition.public_keys()
+
+  # we hold the query separate from the shape definition in order to allow
+  # for transformation of a query to a shape definition at runtime rather
+  # than compile time.
+  defstruct [
+    :shape_config,
+    :api_config,
+    :stream_config,
+    :query
+  ]
 
   @type t :: %__MODULE__{}
+  @type options() :: [unquote(NimbleOptions.option_typespec(@public_schema))]
 
-  def schema, do: @schema
-  def keys, do: @keys
+  if Code.ensure_loaded?(Ecto) do
+    @type shape() :: options() | Electric.Client.ecto_shape()
+  else
+    @type shape() :: options()
+  end
 
+  def schema, do: @public_schema
+
+  @spec new!(shape(), options()) :: t()
   def new!(opts, config \\ [])
 
-  def new!(shape, opts) when is_list(opts) and is_list(shape) do
-    config = NimbleOptions.validate!(Keyword.merge(shape, opts), @schema)
-    new(Keyword.put(config, :relation, build_relation!(config)))
+  def new!(shape, opts) when is_list(shape) and is_list(opts) do
+    shape
+    |> Keyword.merge(opts)
+    |> split_and_validate_opts!(mode: :keyword)
+    |> new()
   end
 
-  def new!(schema, opts) when is_atom(schema) do
-    new(Keyword.put(opts, :query, schema))
+  def new!(table, opts) when is_binary(table) and is_list(opts) do
+    new!([table: table], opts)
   end
 
-  def new!(%Ecto.Query{} = query, opts) do
-    new(Keyword.put(opts, :query, query))
-  end
-
-  defp new(opts) do
-    struct(__MODULE__, opts)
-  end
-
-  defp build_relation!(opts) do
-    build_relation(opts) ||
-      raise ArgumentError,
-        message: "missing relation or table in #{inspect(opts)}"
-  end
-
-  defp build_relation(opts) do
-    case Keyword.get(opts, :relation) do
-      {_namespace, _table} = relation ->
-        relation
-
-      nil ->
-        case Keyword.get(opts, :table) do
-          table when is_binary(table) ->
-            namespace = Keyword.get(opts, :namespace, "public")
-            {namespace, table}
-
-          _ ->
-            nil
-        end
-
-      _ ->
-        nil
+  if Code.ensure_loaded?(Ecto) do
+    def new!(ecto_shape, opts)
+        when is_atom(ecto_shape) or is_struct(ecto_shape, Ecto.Query) or
+               is_function(ecto_shape, 1) or
+               is_struct(ecto_shape, Ecto.Changeset) do
+      opts
+      |> split_and_validate_opts!(mode: :ecto)
+      |> Keyword.merge(query: ecto_shape)
+      |> new()
     end
+  end
+
+  defp new(opts), do: struct(__MODULE__, opts)
+
+  defp split_and_validate_opts!(opts, mode) do
+    {shape_opts, other_opts} = Keyword.split(opts, @shape_definition_keys)
+    {api_opts, other_opts} = Keyword.split(other_opts, @api_schema_keys)
+
+    stream_opts =
+      case Keyword.split(other_opts, @stream_schema_keys) do
+        {stream_opts, []} ->
+          stream_opts
+
+        {_stream_opts, invalid_opts} ->
+          raise ArgumentError,
+            message: "received invalid options to a shape definition: #{inspect(invalid_opts)}"
+      end
+
+    shape_config = validate_shape_config(shape_opts, mode)
+    api_config = NimbleOptions.validate!(api_opts, @api_schema)
+
+    # remove replica value from the stream because it will override the shape
+    # setting and since we've removed the `:replica` value earlier
+    # it'll always be set to default
+    stream_config =
+      NimbleOptions.validate!(stream_opts, @stream_schema)
+      |> Enum.reject(&is_nil(elem(&1, 1)))
+      |> Enum.reject(&(elem(&1, 0) == :replica))
+
+    [shape_config: shape_config, api_config: api_config, stream_config: stream_config]
+  end
+
+  # If we're defining a shape with a keyword list then we need at least the
+  # `table`. Coming from some ecto value, the table is already present
+  defp validate_shape_config(shape_opts, mode: :keyword) do
+    NimbleOptions.validate!(shape_opts, @keyword_shape_schema)
+  end
+
+  defp validate_shape_config(shape_opts, _mode) do
+    NimbleOptions.validate!(shape_opts, @shape_schema)
   end
 
   def client(%Electric.Client{} = client, %__MODULE__{} = predefined_shape) do
     Electric.Client.merge_params(client, to_client_params(predefined_shape))
   end
 
-  defp to_client_params(%__MODULE__{} = predefined_shape) do
-    {{namespace, table}, shape} =
-      predefined_shape
-      |> resolve_query()
-      |> to_list()
-      |> Keyword.pop!(:relation)
-
-    # Remove storage as it's not currently supported as a query param
-    shape
-    |> Keyword.put(:table, ShapeDefinition.url_table_name(namespace, table))
-    |> Keyword.delete(:storage)
-    |> columns_to_query_param()
+  def to_client_params(%__MODULE__{} = predefined_shape) do
+    predefined_shape
+    |> to_shape_definition()
+    |> ShapeDefinition.params()
   end
 
   def to_api_params(%__MODULE__{} = predefined_shape) do
     predefined_shape
-    |> resolve_query()
-    |> to_list()
+    |> to_shape_definition()
+    |> ShapeDefinition.params(format: :keyword)
+    |> Keyword.merge(predefined_shape.api_config)
   end
 
   def to_stream_params(%__MODULE__{} = predefined_shape) do
-    {{namespace, table}, shape} =
-      predefined_shape
-      |> resolve_query()
-      |> to_list()
-      |> Keyword.pop!(:relation)
-
-    {shape_opts, stream_opts} = Keyword.split(shape, ShapeDefinition.public_keys())
-
-    {:ok, shape_definition} =
-      ShapeDefinition.new(table, Keyword.merge(shape_opts, namespace: namespace))
-
-    {shape_definition, stream_opts}
+    {to_shape_definition(predefined_shape), predefined_shape.stream_config}
   end
 
-  defp resolve_query(%__MODULE__{query: nil} = predefined_shape) do
-    predefined_shape
+  defp to_shape_definition(%__MODULE__{query: nil, shape_config: shape_config}) do
+    ShapeDefinition.new!(shape_config)
   end
 
   # we resolve the query at runtime to avoid compile-time dependencies in
   # router modules
-  defp resolve_query(%__MODULE__{} = predefined_shape) do
-    from_queryable!(predefined_shape)
-  end
-
-  defp from_queryable!(%{query: queryable} = predefined_shape) do
-    try do
-      queryable
-      |> Electric.Client.EctoAdapter.shape_from_query!()
-      |> from_shape_definition(predefined_shape)
-    rescue
-      e in Protocol.UndefinedError ->
-        raise ArgumentError,
-          message: "Invalid query `#{inspect(queryable)}`: #{e.description}"
-    end
-  end
-
-  defp from_shape_definition(%ShapeDefinition{} = shape_definition, predefined_shape) do
-    %{
-      namespace: namespace,
-      table: table,
-      where: where,
-      columns: columns
-    } = shape_definition
-
-    %{predefined_shape | relation: {namespace || "public", table}, columns: columns}
-    |> put_if(:where, where)
-  end
-
-  defp put_if(shape, _key, nil), do: shape
-  defp put_if(shape, key, value), do: Map.put(shape, key, value)
-
-  defp to_list(%__MODULE__{} = shape) do
-    Enum.flat_map(@keys, fn key ->
-      value = Map.fetch!(shape, key)
-
-      if !is_nil(value),
-        do: [{key, value}],
-        else: []
-    end)
-  end
-
-  defp columns_to_query_param(shape) do
-    case Keyword.get(shape, :columns) do
-      columns when is_list(columns) -> Keyword.put(shape, :columns, Enum.join(columns, ","))
-      _ -> shape
-    end
+  defp to_shape_definition(%__MODULE__{query: queryable, shape_config: shape_config}) do
+    Electric.Client.EctoAdapter.shape!(queryable, shape_config)
   end
 end

--- a/lib/phoenix/sync/shape_request_registry.ex
+++ b/lib/phoenix/sync/shape_request_registry.ex
@@ -1,0 +1,137 @@
+defmodule Phoenix.Sync.ShapeRequestRegistry do
+  @moduledoc false
+
+  use GenServer
+
+  alias Phoenix.Sync.PredefinedShape
+
+  # Client API
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def register_shape(%PredefinedShape{} = shape) do
+    GenServer.call(__MODULE__, {:register_shape, shape})
+  end
+
+  def unregister_shape(key) do
+    GenServer.call(__MODULE__, {:unregister_shape, key})
+  end
+
+  def interrupt_matching(shape, shape_opts \\ [])
+
+  def interrupt_matching(match_spec, _opts) when is_list(match_spec) do
+    match_spec = Keyword.replace_lazy(match_spec, :params, &normalize_params_form/1)
+
+    do_interrupt_matching(fn shape ->
+      Enum.all?(match_spec, fn {k, v} -> Map.get(shape, k) == v end)
+    end)
+  end
+
+  def interrupt_matching(matcher, _opts) when is_function(matcher, 1) do
+    GenServer.call(__MODULE__, {:interrupt_matching, matcher})
+  end
+
+  def interrupt_matching(queryable, shape_opts)
+      when is_atom(queryable) or is_struct(queryable, Ecto.Query) do
+    match_shape =
+      queryable
+      |> PredefinedShape.new!(shape_opts)
+      |> match_params()
+
+    do_interrupt_matching(fn shape -> match_shape == shape end)
+  rescue
+    e -> {:error, e}
+  end
+
+  def interrupt_matching(table, opts) when is_binary(table) do
+    interrupt_matching(Keyword.put(opts, :table, table))
+  end
+
+  defp do_interrupt_matching(fun) do
+    GenServer.call(__MODULE__, {:interrupt_matching, fun})
+  end
+
+  defp normalize_params_form(params) when is_list(params) do
+    params
+    |> Enum.with_index(fn elem, index -> {to_string(index + 1), to_string(elem)} end)
+    |> Map.new()
+  end
+
+  defp normalize_params_form(params) when is_map(params) do
+    Map.new(params, fn {k, v} -> {to_string(k), to_string(v)} end)
+  end
+
+  def registered_requests do
+    GenServer.call(__MODULE__, :registered_requests)
+  end
+
+  # Server implementation
+
+  @impl GenServer
+  def init(_opts) do
+    {:ok, %{subscriptions: %{}, monitors: %{}}}
+  end
+
+  @impl GenServer
+  def handle_call({:register_shape, shape}, {request_pid, _ref}, state) do
+    %{
+      monitors: monitors,
+      subscriptions: subscriptions
+    } = state
+
+    monitor_ref = Process.monitor(request_pid)
+    monitors = Map.put(monitors, monitor_ref, monitor_ref)
+
+    shape_info = {shape, request_pid}
+    subscriptions = Map.put(subscriptions, monitor_ref, shape_info)
+
+    {:reply, {:ok, monitor_ref}, %{state | monitors: monitors, subscriptions: subscriptions}}
+  end
+
+  def handle_call({:unregister_shape, key}, _from, %{subscriptions: subscriptions} = state) do
+    {:reply, :ok, %{state | subscriptions: Map.delete(subscriptions, key)}}
+  end
+
+  def handle_call({:interrupt_matching, matcher}, _from, state) do
+    interrupted_count =
+      state.subscriptions
+      |> Enum.filter(fn {_id, {shape, _request_pid}} ->
+        shape
+        |> match_params()
+        |> matcher.()
+      end)
+      |> Enum.reduce(0, fn {key, {_shape, request_pid}}, acc ->
+        send(request_pid, {:interrupt_shape, key, :server_interrupt})
+
+        acc + 1
+      end)
+
+    {:reply, {:ok, interrupted_count}, state}
+  end
+
+  def handle_call(:registered_requests, _from, %{subscriptions: subscriptions} = state) do
+    {:reply, Map.to_list(subscriptions), state}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, monitor_ref, :process, _pid, _reason}, state) do
+    case Map.pop(state.monitors, monitor_ref) do
+      {nil, monitors} ->
+        {:noreply, %{state | monitors: monitors}}
+
+      {key, monitors} ->
+        subscriptions = Map.delete(state.subscriptions, key)
+
+        {:noreply, %{state | subscriptions: subscriptions, monitors: monitors}}
+    end
+  end
+
+  defp match_params(%PredefinedShape{} = shape) do
+    shape
+    |> PredefinedShape.to_shape_params()
+    |> Map.new()
+    |> Map.drop([:replica])
+  end
+end

--- a/test/phoenix/sync/application_test.exs
+++ b/test/phoenix/sync/application_test.exs
@@ -119,11 +119,8 @@ defmodule Phoenix.Sync.ApplicationTest do
       validate_repo_connection_opts!(opts)
 
       assert %{
-               storage:
-                 {Electric.ShapeCache.FileStorage, [storage_dir: ^tmp_dir <> "/" <> storage_dir]},
-               persistent_kv: %Electric.PersistentKV.Filesystem{
-                 root: ^tmp_dir <> "/" <> storage_dir
-               }
+               storage: {Electric.ShapeCache.FileStorage, [storage_dir: ^tmp_dir <> storage_dir]},
+               persistent_kv: %Electric.PersistentKV.Filesystem{root: ^tmp_dir <> storage_dir}
              } = Map.new(opts)
     end
 

--- a/test/phoenix/sync/client_test.exs
+++ b/test/phoenix/sync/client_test.exs
@@ -145,6 +145,27 @@ defmodule Phoenix.Sync.ClientTest do
              ] = events
     end
 
+    test "with ecto query and additional shape opts", ctx do
+      stream =
+        Phoenix.Sync.Client.stream(
+          from(t in Support.Todo, where: t.completed == true),
+          [namespace: "app", replica: :full, live: false, errors: :stream],
+          ctx.electric_opts
+        )
+
+      assert %Electric.Client.Stream{
+               client: %{
+                 params: %{
+                   "columns" => "id,title,completed",
+                   "replica" => "full",
+                   "table" => "app.todos",
+                   "where" => "(\"completed\" = TRUE)"
+                 }
+               },
+               opts: %{errors: :stream, live: false}
+             } = stream
+    end
+
     test "with table name", ctx do
       stream =
         Phoenix.Sync.Client.stream(

--- a/test/phoenix/sync/controller_test.exs
+++ b/test/phoenix/sync/controller_test.exs
@@ -39,6 +39,8 @@ defmodule Phoenix.Sync.ControllerTest do
       get "/complete", TodoController, :complete
       get "/flexible", TodoController, :flexible
       get "/module", TodoController, :module
+      get "/changeset", TodoController, :changeset
+      get "/complex", TodoController, :complex
     end
   end
 
@@ -150,6 +152,35 @@ defmodule Phoenix.Sync.ControllerTest do
                %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "one"}},
                %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "two"}},
                %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "three"}}
+             ] = Jason.decode!(resp.resp_body)
+    end
+
+    test "allows for changeset function", _ctx do
+      resp =
+        Phoenix.ConnTest.build_conn()
+        |> Phoenix.ConnTest.get("/todos/changeset", %{offset: "-1"})
+
+      assert resp.status == 200
+      assert Plug.Conn.get_resp_header(resp, "electric-offset") == ["0_0"]
+
+      assert [
+               %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "one"}},
+               %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "two"}},
+               %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "three"}}
+             ] = Jason.decode!(resp.resp_body)
+    end
+
+    test "allows for complex shapes", _ctx do
+      resp =
+        Phoenix.ConnTest.build_conn()
+        |> Phoenix.ConnTest.get("/todos/complex", %{offset: "-1"})
+
+      assert resp.status == 200
+      assert Plug.Conn.get_resp_header(resp, "electric-offset") == ["0_0"]
+
+      assert [
+               %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "one"}},
+               %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "two"}}
              ] = Jason.decode!(resp.resp_body)
     end
   end

--- a/test/phoenix/sync/controller_test.exs
+++ b/test/phoenix/sync/controller_test.exs
@@ -42,7 +42,7 @@ defmodule Phoenix.Sync.ControllerTest do
       get "/changeset", TodoController, :changeset
       get "/complex", TodoController, :complex
       get "/interruptible", TodoController, :interruptible
-      get "/interruptable_dynamic", TodoController, :interruptable_dynamic
+      get "/interruptible_dynamic", TodoController, :interruptible_dynamic
     end
   end
 
@@ -200,7 +200,7 @@ defmodule Phoenix.Sync.ControllerTest do
 
     get "/shape/interruptible-todos" do
       sync_render(conn, fn ->
-        shape_params = Agent.get(:interruptable_dynamic_agent, & &1)
+        shape_params = Agent.get(:interruptible_dynamic_agent, & &1)
 
         Phoenix.Sync.shape!(
           table: "todos",
@@ -264,7 +264,7 @@ defmodule Phoenix.Sync.ControllerTest do
     test "re-tries the request after an interrupt", ctx do
       agent = start_supervised!({Agent, fn -> [false] end})
 
-      Process.register(agent, :interruptable_dynamic_agent)
+      Process.register(agent, :interruptible_dynamic_agent)
 
       conn = conn(:get, "/shape/interruptible-todos", %{"offset" => "-1"})
 
@@ -296,7 +296,7 @@ defmodule Phoenix.Sync.ControllerTest do
       Process.sleep(100)
 
       # change the shape definition while the request is running
-      Agent.update(:interruptable_dynamic_agent, fn _ -> [true] end)
+      Agent.update(:interruptible_dynamic_agent, fn _ -> [true] end)
 
       # interrupt forcing a re-request which will pick up the changed shape definition
       assert {:ok, 1} = Phoenix.Sync.interrupt(table: "todos")
@@ -391,11 +391,11 @@ defmodule Phoenix.Sync.ControllerTest do
     test "returns must-refetch for invalidated shape", _ctx do
       agent = start_supervised!({Agent, fn -> [false] end})
 
-      Process.register(agent, :interruptable_dynamic_agent)
+      Process.register(agent, :interruptible_dynamic_agent)
 
       resp =
         Phoenix.ConnTest.build_conn()
-        |> Phoenix.ConnTest.get("/todos/interruptable_dynamic", %{offset: "-1"})
+        |> Phoenix.ConnTest.get("/todos/interruptible_dynamic", %{offset: "-1"})
 
       assert resp.status == 200
       assert Plug.Conn.get_resp_header(resp, "electric-offset") == ["0_0"]
@@ -404,7 +404,7 @@ defmodule Phoenix.Sync.ControllerTest do
 
       resp =
         Phoenix.ConnTest.build_conn()
-        |> Phoenix.ConnTest.get("/todos/interruptable_dynamic", %{offset: "0_0", handle: handle})
+        |> Phoenix.ConnTest.get("/todos/interruptible_dynamic", %{offset: "0_0", handle: handle})
 
       assert resp.status == 200
       assert Plug.Conn.get_resp_header(resp, "electric-offset") == ["0_inf"]
@@ -414,7 +414,7 @@ defmodule Phoenix.Sync.ControllerTest do
       task =
         Task.async(fn ->
           Phoenix.ConnTest.build_conn()
-          |> Phoenix.ConnTest.get("/todos/interruptable_dynamic", %{
+          |> Phoenix.ConnTest.get("/todos/interruptible_dynamic", %{
             offset: "0_inf",
             handle: handle,
             live: "true"
@@ -425,7 +425,7 @@ defmodule Phoenix.Sync.ControllerTest do
       Process.sleep(100)
 
       # change the shape definition while the request is running
-      Agent.update(:interruptable_dynamic_agent, fn _ -> [true] end)
+      Agent.update(:interruptible_dynamic_agent, fn _ -> [true] end)
 
       # interrupt forcing a re-request which will pick up the changed shape definition
       assert {:ok, 1} = Phoenix.Sync.interrupt(table: "todos")

--- a/test/phoenix/sync/predefined_shape_test.exs
+++ b/test/phoenix/sync/predefined_shape_test.exs
@@ -1,0 +1,150 @@
+defmodule Phoenix.Sync.PredefinedShapeTest do
+  use ExUnit.Case, async: true
+
+  alias Phoenix.Sync.PredefinedShape
+  alias Electric.Client.ShapeDefinition
+
+  defmodule Cow do
+    use Ecto.Schema
+
+    schema "cows" do
+      field :name, :string
+      field :age, :integer
+      field :breed, :string
+    end
+
+    def changeset(data \\ %__MODULE__{}, params) do
+      import Ecto.Changeset
+
+      data
+      |> cast(params, [:name, :age, :breed])
+      |> validate_number(:age, greater_than: 0)
+      |> validate_required([:name])
+      |> update_change(:breed, &String.downcase/1)
+      |> validate_inclusion(:breed, ~w(holstein angus hereford jersey))
+    end
+  end
+
+  describe "new!/2" do
+    test "raises if passed unknown options" do
+      assert_raise ArgumentError, fn ->
+        PredefinedShape.new!(table: "here", sheep: "baa")
+      end
+    end
+
+    test "raises if passed invalid options" do
+      invalid = [
+        [],
+        [where: "something = true"],
+        [table: "here", replica: :invalid],
+        [table: "here", storage: :invalid],
+        [table: "here", params: :invalid],
+        [table: "here", columns: :invalid],
+        [table: "here", namespace: :invalid],
+        [table: "here", where: :invalid],
+        [table: "here", live: :invalid],
+        [table: "here", errors: :invalid]
+      ]
+
+      for opts <- invalid do
+        assert_raise NimbleOptions.ValidationError, fn ->
+          PredefinedShape.new!(opts)
+        end
+      end
+    end
+
+    test "accepts keyword-based shape definition" do
+      ps =
+        PredefinedShape.new!(
+          table: "todos",
+          namespace: "test",
+          where: "completed = $1",
+          params: [true],
+          replica: :full,
+          columns: ["id", "title"],
+          storage: %{compaction: :disabled}
+        )
+
+      assert PredefinedShape.to_client_params(ps) == %{
+               "params[1]" => "true",
+               "replica" => "full",
+               "table" => "test.todos",
+               "where" => "completed = $1",
+               "columns" => "id,title"
+             }
+
+      assert PredefinedShape.to_api_params(ps) |> Enum.sort() ==
+               Enum.sort(
+                 table: "todos",
+                 namespace: "test",
+                 where: "completed = $1",
+                 params: %{"1" => "true"},
+                 replica: :full,
+                 columns: ["id", "title"],
+                 storage: %{compaction: :disabled}
+               )
+    end
+
+    test "accepts Ecto schema" do
+      ps = PredefinedShape.new!(Cow, storage: %{compaction: :disabled})
+
+      assert PredefinedShape.to_client_params(ps) == %{
+               "columns" => "id,name,age,breed",
+               "table" => "cows"
+             }
+
+      assert PredefinedShape.to_api_params(ps) |> Enum.sort() ==
+               Enum.sort(
+                 table: "cows",
+                 columns: ["id", "name", "age", "breed"],
+                 storage: %{compaction: :disabled}
+               )
+    end
+
+    test "accepts Ecto schema plus opts" do
+      ps =
+        PredefinedShape.new!(
+          Cow,
+          namespace: "test",
+          where: "completed = $1",
+          params: [true],
+          replica: :full,
+          columns: ["id", "title"],
+          storage: %{compaction: :disabled}
+        )
+
+      assert PredefinedShape.to_client_params(ps) == %{
+               "columns" => "id,title",
+               "params[1]" => "true",
+               "replica" => "full",
+               "table" => "test.cows",
+               "where" => "completed = $1"
+             }
+    end
+
+    test "changeset function plus opts" do
+      ps =
+        PredefinedShape.new!(
+          &Cow.changeset/1,
+          namespace: "test",
+          where: "completed = $1",
+          params: [true],
+          replica: :full,
+          storage: %{compaction: :disabled},
+          live: false,
+          errors: :stream
+        )
+
+      assert PredefinedShape.to_client_params(ps) == %{
+               "columns" => "id,name,breed,age",
+               "params[1]" => "true",
+               "replica" => "full",
+               "table" => "test.cows",
+               "where" => "completed = $1"
+             }
+
+      assert {%{__struct__: ShapeDefinition}, [live: false, errors: :stream]} =
+               PredefinedShape.to_stream_params(ps)
+    end
+  end
+end

--- a/test/phoenix/sync/router_test.exs
+++ b/test/phoenix/sync/router_test.exs
@@ -54,8 +54,10 @@ defmodule Phoenix.Sync.RouterTest do
         storage: %{compaction: :disabled}
 
       # support shapes from a query, passed as the 2nd arg
-      # #sdf
       sync "/query-where", Support.Todo, where: "completed = false"
+
+      sync "/shape-parameters", table: "todos", where: "completed = $1", params: ["false"]
+      sync "/query-parameters", Support.Todo, where: "completed = $1", params: ["false"]
 
       # or as query: ...
       sync "/query-bare", Support.Todo
@@ -330,6 +332,45 @@ defmodule Phoenix.Sync.RouterTest do
                %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "one"}},
                %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "two"}},
                %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "three"}}
+             ] = Jason.decode!(resp.resp_body)
+    end
+
+    @tag table: {
+           "todos",
+           [
+             "id int8 not null primary key generated always as identity",
+             "title text",
+             "completed boolean default false"
+           ]
+         }
+    @tag data: {
+           "todos",
+           ["title", "completed"],
+           [["one", false], ["two", false], ["three", true]]
+         }
+    test "accepts parameterized where clauses", _ctx do
+      resp =
+        Phoenix.ConnTest.build_conn()
+        |> Phoenix.ConnTest.get("/sync/shape-parameters", %{offset: "-1"})
+
+      assert resp.status == 200
+      assert Plug.Conn.get_resp_header(resp, "electric-offset") == ["0_0"]
+
+      assert [
+               %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "one"}},
+               %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "two"}}
+             ] = Jason.decode!(resp.resp_body)
+
+      resp =
+        Phoenix.ConnTest.build_conn()
+        |> Phoenix.ConnTest.get("/sync/query-parameters", %{offset: "-1"})
+
+      assert resp.status == 200
+      assert Plug.Conn.get_resp_header(resp, "electric-offset") == ["0_0"]
+
+      assert [
+               %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "one"}},
+               %{"headers" => %{"operation" => "insert"}, "value" => %{"title" => "two"}}
              ] = Jason.decode!(resp.resp_body)
     end
 

--- a/test/phoenix/sync_test.exs
+++ b/test/phoenix/sync_test.exs
@@ -100,4 +100,166 @@ defmodule Phoenix.SyncTest do
                )
     end
   end
+
+  describe "interrupt/[1|2]" do
+    alias Phoenix.Sync.PredefinedShape
+    alias Phoenix.Sync.ShapeRequestRegistry
+
+    test "interrupts matching tablename" do
+      test_pid = self()
+
+      # Spawn a separate process to simulate HTTP request process
+      request_process =
+        spawn_link(fn ->
+          # Register shape from this process (simulates HTTP request)
+          shape = PredefinedShape.new!(table: "threads", namespace: "public")
+          {:ok, key} = ShapeRequestRegistry.register_shape(shape)
+
+          # Wait for interruption signal
+          receive do
+            {:interrupt_shape, ^key, :server_interrupt} ->
+              send(test_pid, {:got_interrupt, self()})
+          end
+        end)
+
+      # Give process time to register
+      Process.sleep(10)
+
+      # Interrupt shapes (should target the spawned process)
+      {:ok, count} = Phoenix.Sync.interrupt("threads")
+      assert count == 1
+
+      # Verify the spawned process got the interruption
+      assert_receive {:got_interrupt, ^request_process}
+    end
+
+    test "shape matching w/params" do
+      defns = [
+        [[table: "todos"]],
+        [[table: "todos"]],
+        [[table: "todos", where: "completed = $1"]],
+        [[table: "todos", where: "completed = $1", params: [true]]],
+        [[table: "todos", where: "completed = $1", params: %{1 => true}]]
+      ]
+
+      shape =
+        PredefinedShape.new!(
+          table: "todos",
+          where: "completed = $1",
+          params: [true],
+          columns: ["id", "title"]
+        )
+
+      {:ok, key} = ShapeRequestRegistry.register_shape(shape)
+
+      for args <- defns do
+        assert {:ok, 1} = apply(Phoenix.Sync, :interrupt, args)
+
+        assert_receive {:interrupt_shape, ^key, :server_interrupt}, 500
+      end
+    end
+
+    test "shape matching w/namespace" do
+      import Ecto.Query, only: [from: 2]
+
+      defns = [
+        [[table: "todos"]],
+        [[namespace: "public", table: "todos"]],
+        [[table: "todos", where: "completed = true"]],
+        [Ecto.Query.put_query_prefix(Support.Todo, "public"), [where: "completed = true"]],
+        [fn params -> params[:table] == "todos" end, []]
+      ]
+
+      shape =
+        PredefinedShape.new!(
+          table: "todos",
+          namespace: "public",
+          where: "completed = true",
+          columns: ["id", "title", "completed"]
+        )
+
+      {:ok, key} = ShapeRequestRegistry.register_shape(shape)
+
+      for args <- defns do
+        assert {:ok, 1} = apply(Phoenix.Sync, :interrupt, args)
+
+        assert_receive {:interrupt_shape, ^key, :server_interrupt}, 500
+      end
+    end
+
+    test "shape matching against Ecto.Query" do
+      import Ecto.Query, only: [from: 2]
+
+      defns = [
+        [[table: "todos"]],
+        [[namespace: "public", table: "todos"]],
+        [from(t in Support.Todo, prefix: "public", where: t.completed == true), []],
+        [fn params -> params[:table] == "todos" end, []]
+      ]
+
+      shape =
+        PredefinedShape.new!(
+          from(t in Support.Todo, prefix: "public", where: t.completed == true)
+        )
+
+      {:ok, key} = ShapeRequestRegistry.register_shape(shape)
+
+      for args <- defns do
+        assert {:ok, 1} = apply(Phoenix.Sync, :interrupt, args)
+
+        assert_receive {:interrupt_shape, ^key, :server_interrupt}, 500
+      end
+    end
+
+    test "shape matching w/o namespace" do
+      defns = [
+        ["todos"],
+        [[table: "todos"]],
+        [[table: "todos", where: "completed = true"]],
+        [Support.Todo, [where: "completed = true"]]
+      ]
+
+      shape =
+        PredefinedShape.new!(
+          table: "todos",
+          where: "completed = true",
+          columns: ["id", "title", "completed"]
+        )
+
+      {:ok, key} = ShapeRequestRegistry.register_shape(shape)
+
+      for args <- defns do
+        assert {:ok, 1} = apply(Phoenix.Sync, :interrupt, args)
+
+        assert_receive {:interrupt_shape, ^key, :server_interrupt}, 500
+      end
+    end
+
+    test "shape matching with function" do
+      defns = [
+        [fn %{table: table} -> table == "todos" end, []],
+        [
+          fn %{table: table, where: where} ->
+            table == "todos" and where == "completed = true"
+          end,
+          []
+        ]
+      ]
+
+      shape =
+        PredefinedShape.new!(
+          table: "todos",
+          where: "completed = true",
+          columns: ["id", "title", "completed"]
+        )
+
+      {:ok, key} = ShapeRequestRegistry.register_shape(shape)
+
+      for args <- defns do
+        assert {:ok, 1} = apply(Phoenix.Sync, :interrupt, args)
+
+        assert_receive {:interrupt_shape, ^key, :server_interrupt}, 500
+      end
+    end
+  end
 end

--- a/test/support/controllers/todo_controller.ex
+++ b/test/support/controllers/todo_controller.ex
@@ -21,4 +21,12 @@ defmodule Phoenix.Sync.LiveViewTest.TodoController do
   def module(conn, params) do
     sync_render(conn, params, Support.Todo)
   end
+
+  def changeset(conn, params) do
+    sync_render(conn, params, &Support.Todo.changeset/1)
+  end
+
+  def complex(conn, params) do
+    sync_render(conn, params, &Support.Todo.changeset/1, where: "completed = false")
+  end
 end

--- a/test/support/controllers/todo_controller.ex
+++ b/test/support/controllers/todo_controller.ex
@@ -36,9 +36,9 @@ defmodule Phoenix.Sync.LiveViewTest.TodoController do
     end)
   end
 
-  def interruptable_dynamic(conn, params) do
+  def interruptible_dynamic(conn, params) do
     sync_render(conn, params, fn ->
-      shape_params = Agent.get(:interruptable_dynamic_agent, & &1)
+      shape_params = Agent.get(:interruptible_dynamic_agent, & &1)
 
       Phoenix.Sync.shape!(
         table: "todos",

--- a/test/support/controllers/todo_controller.ex
+++ b/test/support/controllers/todo_controller.ex
@@ -29,4 +29,22 @@ defmodule Phoenix.Sync.LiveViewTest.TodoController do
   def complex(conn, params) do
     sync_render(conn, params, &Support.Todo.changeset/1, where: "completed = false")
   end
+
+  def interruptible(conn, params) do
+    sync_render(conn, params, fn ->
+      &Support.Todo.changeset/1
+    end)
+  end
+
+  def interruptable_dynamic(conn, params) do
+    sync_render(conn, params, fn ->
+      shape_params = Agent.get(:interruptable_dynamic_agent, & &1)
+
+      Phoenix.Sync.shape!(
+        table: "todos",
+        where: "completed = $1",
+        params: shape_params
+      )
+    end)
+  end
 end

--- a/test/support/endpoint.ex
+++ b/test/support/endpoint.ex
@@ -39,9 +39,3 @@ defmodule Phoenix.Sync.LiveViewTest.Endpoint do
     Exception.message(conn.reason)
   end
 end
-
-defmodule Phoenix.ErrorView do
-  def render("500.html", %{reason: exception}) do
-    Exception.message(exception)
-  end
-end

--- a/test/support/todo.ex
+++ b/test/support/todo.ex
@@ -8,7 +8,7 @@ defmodule Support.Todo do
     field :completed, :boolean
   end
 
-  def changeset(todo, data) do
+  def changeset(todo \\ %__MODULE__{}, data) do
     todo
     |> cast(data, [:id, :title, :completed])
     |> validate_required([:id, :title])


### PR DESCRIPTION
Also clean up the shape definition path, removing Phoenix.Sync from the chain of "things that understand shapes" so now if you change the client's view of a shape it should propagate to Phoenix.Sync without changes