### PR TITLE
Add support for passing custom Finch client

### DIFF
--- a/lib/phoenix/sync/electric.ex
+++ b/lib/phoenix/sync/electric.ex
@@ -528,7 +528,11 @@ defmodule Phoenix.Sync.Electric do
   defp http_mode_plug_opts(electric_config) do
     with {:ok, client} <- configure_client(electric_config, :http) do
       # don't decode the body - just pass it directly
-      client = %{client | fetch: {Electric.Client.Fetch.HTTP, [request: [raw: true]]}}
+      request_opts =
+        Keyword.get(electric_config, :request_opts, [])
+        |> Keyword.merge(raw: true)
+
+      client = %{client | fetch: {Electric.Client.Fetch.HTTP, [request: request_opts]}}
       {:ok, %Phoenix.Sync.Electric.ClientAdapter{client: client}}
     end
   end


### PR DESCRIPTION
We want to be able to configure the Finch pool used by PhoeniX.Sync to communicate with Electric in `:http` mode. This changes allows us to do something like below.

**application.ex**
```elixir
  children = [
    # ...
    {Finch,
     name: MyApp.Sync.Finch,
     pools: %{
       default: [protocols: [:http1], size: 300, count: 4]
     }},
    # ...
  ]
```

**config/prod.exs**
```elixir
config :phoenix_sync,
  mode: :http,
  request_opts: [finch: MyApp.Sync.Finch],
  # ...
```